### PR TITLE
fix: update node version in action.yaml due to deprecated warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ branding:
   color: 'green'
   icon: 'anchor'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
I got the following warning while running the action include aliyun/acr-login.

>  Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-js/push

So we need to update Node version from 12 to 16.